### PR TITLE
Support empty coordinates

### DIFF
--- a/feature_test.go
+++ b/feature_test.go
@@ -45,6 +45,19 @@ const (
 			}
 		}
 	`
+
+	featurePointEmpty = `
+	{
+		"type": "Feature",
+		"geometry": {
+			"type": "Point",
+			"coordinates": []
+		},
+		"properties": {
+			"name": "Helsinki"
+		}
+	}
+`
 )
 
 type City struct {
@@ -83,6 +96,23 @@ func TestFeatureDecode(t *testing.T) {
 	}
 }
 
+func TestFeatureDecodeEmpty(t *testing.T) {
+	var city GeoJsonCity
+	err := json.Unmarshal([]byte(featurePointEmpty), &city)
+
+	it.Ok(t).
+		IfNil(err).
+		If(city.Name).Equal("Helsinki").
+		If(city.Geometry).Should().Be().Like(geojson.Point{})
+
+	switch v := city.Geometry.(type) {
+	case *geojson.Point:
+		it.Ok(t).If(v.Coords).Equal(geojson.Coord{})
+	default:
+		t.Errorf("Invaid Coords Type")
+	}
+}
+
 func TestFeatureEncodePoint(t *testing.T) {
 	city := GeoJsonCity{
 		Feature: geojson.NewPoint(city_helsinki, geojson.Coord{100.0, 0.0}),
@@ -100,6 +130,32 @@ func TestFeatureEncodePoint(t *testing.T) {
 		If(c.ID).Equal(city_helsinki).
 		If(c.Name).Equal(city.Name).
 		If(c.Geometry).Should().Be().Like(geojson.Point{})
+}
+
+func TestFeatureEncodePointEmpty(t *testing.T) {
+	city := GeoJsonCity{
+		Feature: geojson.NewPoint(city_helsinki, geojson.Coord{}),
+		City:    City{Name: "Helsinki"},
+	}
+
+	data, err := json.Marshal(city)
+	it.Ok(t).IfNil(err)
+
+	var c GeoJsonCity
+	err = json.Unmarshal([]byte(data), &c)
+
+	it.Ok(t).
+		IfNil(err).
+		If(c.ID).Equal(city_helsinki).
+		If(c.Name).Equal(city.Name).
+		If(c.Geometry).Should().Be().Like(geojson.Point{})
+
+	switch v := city.Geometry.(type) {
+	case *geojson.Point:
+		it.Ok(t).If(v.Coords).Equal(geojson.Coord{})
+	default:
+		t.Errorf("Invaid Coords Type")
+	}
 }
 
 func TestFeatureEncodeMultiPoint(t *testing.T) {

--- a/geometry.go
+++ b/geometry.go
@@ -67,7 +67,7 @@ func decodeGeometry(b []byte) (Geometry, error) {
 
 // Point type, the "coordinates" member is a single position.
 type Point struct {
-	Coords Coord `json:"coordinates,omitempty"`
+	Coords Coord `json:"coordinates"`
 }
 
 func (geo *Point) Geometry() Shape { return geo.Coords }
@@ -123,7 +123,7 @@ func (geo *Point) unmarshalGeoJSON(b []byte) error {
 
 // MultiPoint type, the "coordinates" member is an array of positions.
 type MultiPoint struct {
-	Coords Curve `json:"coordinates,omitempty"`
+	Coords Curve `json:"coordinates"`
 }
 
 func (geo *MultiPoint) Geometry() Shape { return geo.Coords }
@@ -180,7 +180,7 @@ func (geo *MultiPoint) unmarshalGeoJSON(b []byte) error {
 // LineString type, the "coordinates" member is an array of two or
 // more positions.
 type LineString struct {
-	Coords Curve `json:"coordinates,omitempty"`
+	Coords Curve `json:"coordinates"`
 }
 
 func (geo *LineString) Geometry() Shape { return geo.Coords }
@@ -237,7 +237,7 @@ func (geo *LineString) unmarshalGeoJSON(b []byte) error {
 // MultiLineString type, the "coordinates" member is an array of
 // LineString coordinate arrays.
 type MultiLineString struct {
-	Coords Surface `json:"coordinates,omitempty"`
+	Coords Surface `json:"coordinates"`
 }
 
 func (geo *MultiLineString) Geometry() Shape { return geo.Coords }
@@ -298,7 +298,7 @@ func (geo *MultiLineString) unmarshalGeoJSON(b []byte) error {
 // The first and last positions are equivalent, and they MUST contain
 // identical values; their representation SHOULD also be identical.
 type Polygon struct {
-	Coords Surface `json:"coordinates,omitempty"`
+	Coords Surface `json:"coordinates"`
 }
 
 func (geo *Polygon) Geometry() Shape { return geo.Coords }
@@ -355,7 +355,7 @@ func (geo *Polygon) unmarshalGeoJSON(b []byte) error {
 // MultiPolygon type, the "coordinates" member is an array of
 // Polygon coordinate arrays.
 type MultiPolygon struct {
-	Coords Surfaces `json:"coordinates,omitempty"`
+	Coords Surfaces `json:"coordinates"`
 }
 
 func (geo *MultiPolygon) Geometry() Shape { return geo.Coords }

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -158,10 +158,18 @@ func TestGeometryPoint(t *testing.T) {
 	)
 }
 
+func TestGeometryPointEmpty(t *testing.T) {
+	testGeometry[*geojson.Point](t, "Point", geojson.Coord{}, nil)
+}
+
 func TestGeometryMultiPoint(t *testing.T) {
 	testGeometry[*geojson.MultiPoint](t, "MultiPoint", coordMultiPoint,
 		geojson.BoundingBox{100.0, 0, 101.0, 1.0},
 	)
+}
+
+func TestGeometryMultiPointEmpty(t *testing.T) {
+	testGeometry[*geojson.MultiPoint](t, "MultiPoint", geojson.Curve{}, nil)
 }
 
 func TestGeometryLineString(t *testing.T) {
@@ -170,16 +178,28 @@ func TestGeometryLineString(t *testing.T) {
 	)
 }
 
+func TestGeometryLineStringEmpty(t *testing.T) {
+	testGeometry[*geojson.LineString](t, "LineString", geojson.Curve{}, nil)
+}
+
 func TestGeometryMultiLineString(t *testing.T) {
 	testGeometry[*geojson.MultiLineString](t, "MultiLineString", coordMultiLineString,
 		geojson.BoundingBox{100.0, 0, 103.0, 3.0},
 	)
 }
 
+func TestGeometryMultiLineStringEmpty(t *testing.T) {
+	testGeometry[*geojson.MultiLineString](t, "MultiLineString", geojson.Surface{}, nil)
+}
+
 func TestGeometryPolygon(t *testing.T) {
 	testGeometry[*geojson.Polygon](t, "Polygon", coordPolygon,
 		geojson.BoundingBox{100.0, 0, 101.0, 1.0},
 	)
+}
+
+func TestGeometryPolygonEmpty(t *testing.T) {
+	testGeometry[*geojson.Polygon](t, "Polygon", geojson.Surface{}, nil)
 }
 
 func TestGeometryPolygonWithHole(t *testing.T) {
@@ -192,6 +212,10 @@ func TestGeometryMultiPolygon(t *testing.T) {
 	testGeometry[*geojson.MultiPolygon](t, "MultiPolygon", coordMultiPolygon,
 		geojson.BoundingBox{100.0, 0, 103.0, 3.0},
 	)
+}
+
+func TestGeometryMultiPolygonEmpty(t *testing.T) {
+	testGeometry[*geojson.MultiPolygon](t, "MultiPolygon", geojson.Surfaces{}, nil)
 }
 
 func TestEmptyGeometry(t *testing.T) {


### PR DESCRIPTION
Geometry Object

   A Geometry object represents points, curves, and surfaces in
   coordinate space.  Every Geometry object is a GeoJSON object no
   matter where it occurs in a GeoJSON text.

   o  The value of a Geometry object's "type" member MUST be one of the
      seven geometry types (see [Section 1.4](https://www.rfc-editor.org/rfc/rfc7946#section-1.4)).

   o  A GeoJSON Geometry object of any type other than
      "GeometryCollection" has a member with the name "coordinates".
      The value of the "coordinates" member is an array.  The structure
      of the elements in this array is determined by the type of
      geometry.  **GeoJSON processors MAY interpret Geometry objects with
      empty "coordinates" arrays as null objects.**
